### PR TITLE
Fix: only trim options when the user is done editing.

### DIFF
--- a/src/components/RecipeStepParameters.js
+++ b/src/components/RecipeStepParameters.js
@@ -68,7 +68,10 @@ const OptionField = ({ index, option, updateOption, deleteOption }) => {
           type="text"
           value={option.text}
           onChange={e => {
-            updateOption({ ...option, text: e.target.value.trim() }, index)
+            updateOption({ ...option, text: e.target.value}, index)
+          }}
+          onBlur={e => {  // Trim text when done editing
+            updateOption({ ...option, text: option.text.trim() }, index)
           }}
         />
         <label htmlFor={`${option}-next`}>Next step:</label>


### PR DESCRIPTION
Fixes an issue where options can have NO whitespace - we only want to trim when they are done editing.